### PR TITLE
Use public TimedOut var in broker

### DIFF
--- a/inmem/inmem.go
+++ b/inmem/inmem.go
@@ -1,11 +1,11 @@
 package inmem
 
 import (
-	"fmt"
 	"reflect"
 	"sync"
 	"time"
 
+	"github.com/armon/relay"
 	"github.com/armon/relay/broker"
 )
 
@@ -122,7 +122,7 @@ func (i *InmemConsumer) ConsumeTimeout(out interface{}, timeout time.Duration) e
 		case <-time.After(time.Millisecond):
 			continue
 		case <-timeoutCh:
-			return fmt.Errorf("Timeout")
+			return relay.TimedOut
 		}
 	}
 

--- a/inmem/inmem_test.go
+++ b/inmem/inmem_test.go
@@ -3,6 +3,8 @@ package inmem
 import (
 	"testing"
 	"time"
+
+	"github.com/armon/relay"
 )
 
 func TestInmemBroker(t *testing.T) {
@@ -86,7 +88,7 @@ func TestInmemBroker(t *testing.T) {
 
 	// Should timeout
 	err = cons.ConsumeTimeout(&out, 5*time.Millisecond)
-	if err.Error() != "Timeout" {
+	if err != relay.TimedOut {
 		t.Fatalf("err: %v", err)
 	}
 }


### PR DESCRIPTION
Switch the inmem broker to use the new `relay.TimedOut` for timeout errors.
