### PR TITLE
Add support for custom routing keys.

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -251,12 +251,12 @@ func (r *Relay) Close() error {
 // Consumer will return a new handle that can be used
 // to consume messages from a given queue.
 func (r *Relay) Consumer(queue string) (*Consumer, error) {
-	return r.ConsumerByRoutingKey(queue, queue)
+	return r.ConsumerWithRoutingKey(queue, queue)
 }
 
-// ConsumerByRoutingKey will return a new handle that can be used
+// ConsumerWithRoutingKey will return a new handle that can be used
 // to consume messages from a given queue and routing key.
-func (r *Relay) ConsumerByRoutingKey(queue string, routingKey string) (*Consumer, error) {
+func (r *Relay) ConsumerWithRoutingKey(queue string, routingKey string) (*Consumer, error) {
 
 	// Get a new channel
 	ch, err := r.getChan(&r.consConn)


### PR DESCRIPTION
This extends the work that @wolfeidau did in #7 by adding a very basic test to ensure that messages can be produced and consumed with the routing key. I also renamed `ConsumerByRoutingKey` to `ConsumerWithRoutingKey` to be consistent with the API of the Producer.

This should supersede #7. 