### PR TITLE
Add config for custom exchange type

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -210,8 +210,11 @@ func (r *Relay) declareQueue(ch *amqp.Channel, name string, routingKey string) e
 		args["x-expires"] = msec
 	}
 
+	// Automatically use an exclusive queue if an empty name is provided.
+	exclusive := name == ""
+
 	// Declare the queue
-	if _, err := ch.QueueDeclare(name, true, false, false, false, args); err != nil {
+	if _, err := ch.QueueDeclare(name, true, false, exclusive, false, args); err != nil {
 		return fmt.Errorf("Failed to declare queue '%s'! Got: %s", name, err)
 	}
 

--- a/relay.go
+++ b/relay.go
@@ -24,6 +24,7 @@ type Config struct {
 	DisablePublishConfirm bool          // Disables confirmations of publish
 	DisablePersistence    bool          // Disables message persistence
 	Exchange              string        // Custom exchange. Defaults to "relay"
+	ExchangeType          string        // Type of exchange. Defaults to "direct"
 	Serializer            Serializer    // Defaults to GOBSerializer
 	MessageTTL            time.Duration // Optional, attempts to put a TTL on message life
 	QueueTTL              time.Duration // Optional, attempts to make a TTL on a queue life
@@ -105,6 +106,9 @@ func New(c *Config) (*Relay, error) {
 	}
 	if c.Exchange == "" {
 		c.Exchange = "relay"
+	}
+	if c.ExchangeType == "" {
+		c.ExchangeType = "direct"
 	}
 	if c.Serializer == nil {
 		c.Serializer = &GOBSerializer{}
@@ -188,7 +192,7 @@ func (r *Relay) getChan(conn **amqp.Connection) (*amqp.Channel, error) {
 
 	// Declare an exchange if this is a new connection
 	if isNew {
-		if err := ch.ExchangeDeclare(r.conf.Exchange, "direct", true, false, false, false, nil); err != nil {
+		if err := ch.ExchangeDeclare(r.conf.Exchange, r.conf.ExchangeType, true, false, false, false, nil); err != nil {
 			return nil, fmt.Errorf("Failed to declare exchange '%s'! Got: %s", r.conf.Exchange, err)
 		}
 	}

--- a/relay_test.go
+++ b/relay_test.go
@@ -731,3 +731,123 @@ func TestCustomRoutingKey(t *testing.T) {
 		t.Fatalf("unexpected msg! %v %v", in, msg)
 	}
 }
+
+func TestExclusiveQueue(t *testing.T) {
+	CheckInteg(t)
+
+	// Make the config
+	config := &Config{
+		Addr:     AMQPHost(),
+		Exchange: "exclusive-test",
+	}
+
+	for i := 0; i < 3; i++ {
+		// Create a publisher with an exclusive queue
+		r, err := New(config)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		pub, err := r.Publisher("") // exclusive
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		// Publish a message
+		if err := pub.Publish("foo"); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		// Close the publisher
+		pub.Close()
+	}
+
+	// Create a consumer with the same name
+	r, err := New(config)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	cons, err := r.Consumer("") // exclusive
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer cons.Close()
+
+	// Try consuming. Queue should be empty.
+	var out string
+	if err := cons.ConsumeTimeout(&out, time.Second); err != TimedOut {
+		t.Fatalf("expected empty queue, got: %v", out)
+	}
+}
+
+func TestExchangeType_Fanout(t *testing.T) {
+	CheckInteg(t)
+
+	// Make the config
+	config := &Config{
+		Addr:         AMQPHost(),
+		Exchange:     "fanout-test",
+		ExchangeType: "fanout",
+	}
+
+	// Create the wait group
+	var wg sync.WaitGroup
+	wg.Add(10)
+
+	// Signal the channel when everyone is done
+	doneCh := make(chan struct{})
+	go func() {
+		defer close(doneCh)
+		wg.Wait()
+	}()
+
+	// Start all of the consumers
+	for i := 0; i < 10; i++ {
+		go func() {
+			defer wg.Done()
+
+			r, err := New(config)
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			defer r.Close()
+
+			cons, err := r.Consumer("") // exclusive
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+
+			var out string
+			if err := cons.Consume(&out); err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			cons.Ack()
+		}()
+	}
+
+	// Wait for consumers to all start
+	time.Sleep(time.Second)
+
+	// Set up the publisher
+	r, err := New(config)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	pub, err := r.Publisher("") // exclusive
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Publish a single message
+	if err := pub.Publish("hi"); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Every consumer should get a copy.
+	select {
+	case <-doneCh:
+	case <-time.After(time.Second):
+		t.Fatalf("should fanout")
+	}
+}

--- a/relay_test.go
+++ b/relay_test.go
@@ -74,6 +74,31 @@ func TestConfigFromURI(t *testing.T) {
 	}
 }
 
+func TestConfigDefaults(t *testing.T) {
+	r, err := New(&Config{})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if r.conf.Vhost != "/" {
+		t.Fatalf("bad vhost: %q", r.conf.Vhost)
+	}
+	if r.conf.Username != "guest" {
+		t.Fatalf("bad username: %q", r.conf.Username)
+	}
+	if r.conf.Password != "guest" {
+		t.Fatalf("bad password: %q", r.conf.Password)
+	}
+	if r.conf.Exchange != "relay" {
+		t.Fatalf("bad exchange: %q", r.conf.Exchange)
+	}
+	if r.conf.ExchangeType != "direct" {
+		t.Fatalf("bad exchange type: %q", r.conf.ExchangeType)
+	}
+	if r.conf.PrefetchCount != 1 {
+		t.Fatalf("bad prefetch count: %d", r.conf.PrefetchCount)
+	}
+}
+
 func TestSimplePublishConsume(t *testing.T) {
 	CheckInteg(t)
 

--- a/util.go
+++ b/util.go
@@ -10,6 +10,11 @@ import (
 
 // Converts the user input name into the actual name
 func queueName(name string) string {
+	// Allow using a nameless queue
+	if name == "" {
+		return name
+	}
+
 	return "relay." + name
 }
 

--- a/util_test.go
+++ b/util_test.go
@@ -5,8 +5,11 @@ import (
 )
 
 func TestQueueName(t *testing.T) {
-	if queueName("test") != "relay.test" {
-		t.Fatalf("bad queue name")
+	if name := queueName("test"); name != "relay.test" {
+		t.Fatalf("bad queue name: %q", name)
+	}
+	if name := queueName(""); name != "" {
+		t.Fatalf("bad queue name: %q", name)
 	}
 }
 


### PR DESCRIPTION
Enables using relay with exchange types other than `direct`. /cc @armon