### PR TITLE
Make publishers thread-safe

### DIFF
--- a/publisher.go
+++ b/publisher.go
@@ -18,7 +18,6 @@ type Publisher struct {
 	channel     *amqp.Channel
 	contentType string
 	mode        uint8
-	buf         bytes.Buffer
 	ackCh       chan uint64
 	nackCh      chan uint64
 	errCh       chan *amqp.Error
@@ -33,8 +32,7 @@ func (p *Publisher) Publish(in interface{}) error {
 
 	// Encode the message
 	conf := p.conf
-	buf := &p.buf
-	buf.Reset()
+	buf := new(bytes.Buffer)
 	if err := conf.Serializer.RelayEncode(buf, in); err != nil {
 		return fmt.Errorf("Failed to encode message! Got: %s", err)
 	}


### PR DESCRIPTION
Switches to using a buffer per call to Publish() rather than a global shared one. A `bytes.Buffer` is not thread safe, so if you have a publisher in use in multiple goroutines, it is possible that they will interfere with eachother and write unpredictable messages to the AMQP server.

There are two alternative approaches to this:

1. Document publishers are *not* thread safe. We should probably do that at the broker level even so that the contract is clear.
2. Wrap a mutex around the calls to Publish().

@armon either way you want to go is fine with me. Let me know what you think.