### PR TITLE
Add a wrapper around amqp.Delivery for leveraging message properties

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -1,11 +1,11 @@
 package relay
 
 import (
-	"bytes"
 	"fmt"
-	"github.com/streadway/amqp"
 	"strings"
 	"time"
+
+	"github.com/streadway/amqp"
 )
 
 // Consumer is a type that is used only for consuming messages from a single queue.
@@ -25,19 +25,44 @@ type Consumer struct {
 // message must be acknowledged with Ack() or Nack() before
 // the next call to Consume unless EnableMultiAck is true.
 func (c *Consumer) ConsumeTimeout(out interface{}, timeout time.Duration) error {
+	d, err := c.DeliverTimeout(timeout)
+	if err != nil {
+		return err
+	}
+
+	// Store the delivery tag for future Ack
+	c.lastMsg = d.delivery.DeliveryTag
+	c.needAck = true
+	c.numNoAck++
+
+	// Decode the message
+	if err := d.Decode(out); err != nil {
+		// Since we have dequeued, we must now Nack, since the consumer
+		// will not ever receive the message. This way redelivery is possible.
+		d.Nack()
+		return fmt.Errorf("Failed to decode message! Got: %s", err)
+	}
+
+	return nil
+}
+
+// Deliver will consume the next available delivery or times out waiting. Use of this method is
+// only suggested when you need to access delivery properties, otherwise use of ConsumeTimeout
+// method is strongly encouraged
+func (c *Consumer) DeliverTimeout(timeout time.Duration) (*Delivery, error) {
 	// Check if we are closed
 	if c.channel == nil {
-		return ChannelClosed
+		return nil, ChannelClosed
 	}
 
 	// Check if an ack is required
 	if c.needAck && !c.conf.EnableMultiAck {
-		return fmt.Errorf("Ack required before consume!")
+		return nil, fmt.Errorf("Ack required before consume!")
 	}
 
 	// Check if we've reached the prefetch count without Ack'ing
 	if c.conf.EnableMultiAck && c.numNoAck >= c.conf.PrefetchCount {
-		return fmt.Errorf("Consume will block without Ack!")
+		return nil, fmt.Errorf("Consume will block without Ack!")
 	}
 
 	// Get a timeout
@@ -47,31 +72,20 @@ func (c *Consumer) ConsumeTimeout(out interface{}, timeout time.Duration) error 
 	}
 
 	// Wait for a message
-	var d amqp.Delivery
 	var ok bool
+	d := c.Delivery()
+	var delivery amqp.Delivery
 	select {
-	case d, ok = <-c.deliverChan:
+	case delivery, ok = <-c.deliverChan:
 		if !ok {
-			return ChannelClosed
+			return nil, ChannelClosed
 		}
 	case <-wait:
-		return TimedOut
+		return nil, TimedOut
 	}
+	d.delivery = &delivery
 
-	// Store the delivery tag for future Ack
-	c.lastMsg = d.DeliveryTag
-	c.needAck = true
-	c.numNoAck++
-
-	// Decode the message
-	buf := bytes.NewBuffer(d.Body)
-	if err := c.conf.Serializer.RelayDecode(buf, out); err != nil {
-		// Since we have dequeued, we must now Nack, since the consumer
-		// will not ever receive the message. This way redelivery is possible.
-		c.Nack()
-		return fmt.Errorf("Failed to decode message! Got: %s", err)
-	}
-	return nil
+	return d, nil
 }
 
 // Consume will consume the next available message. The
@@ -79,6 +93,12 @@ func (c *Consumer) ConsumeTimeout(out interface{}, timeout time.Duration) error 
 // the next call to Consume unless EnableMultiAck is true.
 func (c *Consumer) Consume(out interface{}) error {
 	return c.ConsumeTimeout(out, -1)
+}
+
+// Deliver will consume the next available delivery. Use of this method is only suggested when you need to
+// access delivery properties, otherwise use of Consume() method is strongly encouraged
+func (c *Consumer) Deliver() (*Delivery, error) {
+	return c.DeliverTimeout(-1)
 }
 
 // ConsumeAck will consume the next message and acknowledge
@@ -169,6 +189,15 @@ func (c *Consumer) Close() error {
 
 	// Shutdown the channel
 	return c.channel.Close()
+}
+
+// Delivery will create a wrapper around amqp.Delivery struct
+func (c *Consumer) Delivery() *Delivery {
+	return &Delivery{
+		delivery:       new(amqp.Delivery),
+		serializer:     c.conf.Serializer,
+		enableMultiAck: c.conf.EnableMultiAck,
+	}
 }
 
 // IsDecodeFailure is a helper to determine if the error returned is a

--- a/delivery.go
+++ b/delivery.go
@@ -1,0 +1,60 @@
+package relay
+
+import (
+	"bytes"
+
+	"github.com/streadway/amqp"
+)
+
+// Delivery is a type that is used for having more control on consumed messages.
+// Main purpose is having access to message properties
+type Delivery struct {
+	delivery       *amqp.Delivery
+	serializer     Serializer
+	enableMultiAck bool
+}
+
+// Decode will decode the delivery body with the serialization type set within the consumer
+func (d *Delivery) Decode(out interface{}) error {
+	buf := bytes.NewBuffer(d.delivery.Body)
+
+	return d.serializer.RelayDecode(buf, out)
+}
+
+// Properties will extract the properties from amqp.Delivery, and
+func (d *Delivery) Properties() *Properties {
+	return &Properties{
+		Headers:       map[string]interface{}(d.delivery.Headers),
+		CorrelationId: d.delivery.CorrelationId,
+		ReplyTo:       d.delivery.ReplyTo,
+		MessageId:     d.delivery.MessageId,
+		Type:          d.delivery.Type,
+		UserId:        d.delivery.UserId,
+		AppId:         d.delivery.AppId,
+	}
+}
+
+// Ack will send an acknowledgement to the server for the delivery. It gets multiple acknowledge
+// information from its consumer
+func (d *Delivery) Ack() error {
+	return d.delivery.Ack(d.enableMultiAck)
+}
+
+// Nack will send a negative acknowledgement to the server for the delivery. It gets multiple acknowledge
+// information from its consumer
+func (d *Delivery) Nack() error {
+	// Requeing set true by default regarding to Consumer.Nack functionality, but
+	// it will be better to have it configurable
+	return d.delivery.Nack(d.enableMultiAck, true)
+}
+
+// Properties is a type that is used for setting and reading the amqp properties for each message
+type Properties struct {
+	Headers       map[string]interface{}
+	CorrelationId string
+	ReplyTo       string
+	MessageId     string
+	Type          string
+	UserId        string
+	AppId         string
+}


### PR DESCRIPTION
It would be against the simplicity of this package, but I added a wrapper around amqp.Delivery for accessing properties of a message. This PR introduces:

- PublishWithProperties() method: Used for adding properties to the published message
- Deliver()/DeliverTimeout(): Used for consuming messages with its properties. Can be used interchangeably with Consume()/ConsumeTimeout().

Also introduced a Properties struct, and moved all amqp application properties into here. 

 