### PR TITLE
Dead Letter Exchange

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -123,8 +123,8 @@ func (c *Consumer) Nack() error {
 	if !c.needAck {
 		fmt.Errorf("Nack is not required!")
 	}
-	if err := c.channel.Nack(c.lastMsg,
-		c.conf.EnableMultiAck, true); err != nil {
+	requeue := !c.conf.DisableNackRequeue
+	if err := c.channel.Nack(c.lastMsg, c.conf.EnableMultiAck, requeue); err != nil {
 		return err
 	}
 	c.needAck = false
@@ -162,7 +162,8 @@ func (c *Consumer) Close() error {
 
 	// Send a Nack for all these messages
 	if needAck {
-		if err := c.channel.Nack(lastMsg, true, true); err != nil {
+		requeue := !c.conf.DisableNackRequeue
+		if err := c.channel.Nack(lastMsg, true, requeue); err != nil {
 			return fmt.Errorf("Failed to send Nack for inflight messages! Got: %s", err)
 		}
 	}

--- a/consumer.go
+++ b/consumer.go
@@ -123,7 +123,7 @@ func (c *Consumer) Nack() error {
 	if !c.needAck {
 		fmt.Errorf("Nack is not required!")
 	}
-	requeue := !c.conf.DisableNackRequeue
+	requeue := (c.conf.DeadLetter == nil)
 	if err := c.channel.Nack(c.lastMsg, c.conf.EnableMultiAck, requeue); err != nil {
 		return err
 	}
@@ -162,7 +162,7 @@ func (c *Consumer) Close() error {
 
 	// Send a Nack for all these messages
 	if needAck {
-		requeue := !c.conf.DisableNackRequeue
+		requeue := (c.conf.DeadLetter == nil)
 		if err := c.channel.Nack(lastMsg, true, requeue); err != nil {
 			return fmt.Errorf("Failed to send Nack for inflight messages! Got: %s", err)
 		}


### PR DESCRIPTION
I ended up with a message in my queue that failed to de-serialize, but since a failure in serialization just nack'd and re-queued, my consumer was stuck in an endless loop.

I decided I'd rather have all nack'd messages end up in a dead letter queue, so I've added support for that. Let me know what you think!