### PR TITLE
retry: Warn on publish/consume errors until we have to give up.

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -209,7 +209,7 @@ func (rc *retryConsumer) ConsumeTimeout(out interface{}, timeout time.Duration) 
 		}
 
 	RETRY:
-		log.Printf("[ERR] relay: consumer got error: %v", err)
+		log.Printf("[WARN] relay: consumer got error: %v", err)
 		rc.discard(cons)
 		if i == rc.attempts {
 			log.Printf("[ERR] relay: consumer giving up after %d attempts", i)
@@ -320,7 +320,7 @@ func (rp *retryPublisher) Publish(in interface{}) error {
 		}
 
 	RETRY:
-		log.Printf("[ERR] relay: publisher got error: %v", err)
+		log.Printf("[WARN] relay: publisher got error: %v", err)
 		rp.discard(pub)
 		if i == rp.attempts {
 			log.Printf("[ERR] relay: publisher giving up after %d attempts", i)


### PR DESCRIPTION
ERR-level logs are alertable, so we should avoid logging them unless we
are in a hard fail scenario. Lower the level to WARN until we run out of
retries, at which point we can emit an ERR because there is a real
unrecoverable problem.

@phinze