### PR TITLE
Add Redis Broker

### DIFF
--- a/redis/cleanup.go
+++ b/redis/cleanup.go
@@ -1,0 +1,1 @@
+package redis

--- a/redis/reclaim.go
+++ b/redis/reclaim.go
@@ -1,0 +1,170 @@
+package redis
+
+import (
+	"log"
+	"strings"
+	"time"
+
+	"github.com/go-redis/redis"
+)
+
+func (b *RedisBroker) Reclaim(q string) (int, error) {
+	lists, err := b.client.Keys(b.tempListName(q) + "*").Result()
+	if err != nil {
+		return 0, err
+	}
+
+	var cnt int
+
+	for _, list := range lists {
+		for {
+			val, err := b.client.RPopLPush(list, b.listName(q)).Bytes()
+			if err != nil {
+				if err == redis.Nil {
+					break
+				}
+
+				return cnt, err
+			}
+
+			if val == nil {
+				break
+			}
+
+			cnt++
+		}
+	}
+
+	return cnt, nil
+}
+
+func (b *RedisBroker) queueFromTemp(tmp string) string {
+	prefix := len(b.tempListName(""))
+
+	dash := strings.LastIndexByte(tmp, ':')
+	if dash == -1 {
+		return ""
+	}
+
+	return tmp[prefix:dash]
+}
+
+func (b *RedisBroker) ReclaimFromDead() (int, error) {
+	clients, err := b.findDeadClients()
+	if err != nil {
+		return 0, err
+	}
+
+	var cnt int
+
+	for _, client := range clients {
+		lists, err := b.client.Keys(b.tempClientPrefix(client) + "*").Result()
+		if err != nil {
+			return 0, err
+		}
+
+		for _, list := range lists {
+			for {
+				q := b.queueFromTemp(list)
+				if q == "" {
+					continue
+				}
+
+				val, err := b.client.RPopLPush(list, b.listName(q)).Bytes()
+				if err != nil {
+					if err == redis.Nil {
+						break
+					}
+
+					return cnt, err
+				}
+
+				if val == nil {
+					break
+				}
+
+				cnt++
+			}
+		}
+	}
+
+	return cnt, nil
+}
+
+var (
+	heartbeatInterval = 10 * time.Second
+	deadDuration      = 20 * time.Second
+	deadCheckInterval = time.Minute
+)
+
+func (rb *RedisBroker) heartbeat() {
+	defer rb.wg.Done()
+
+	ticker := time.NewTicker(heartbeatInterval)
+	defer ticker.Stop()
+
+	rb.updateHeartbeat()
+
+	for {
+		select {
+		case <-rb.ctx.Done():
+			return
+		case <-ticker.C:
+			rb.updateHeartbeat()
+		}
+	}
+}
+
+func (rb *RedisBroker) updateHeartbeat() error {
+	return rb.client.HSet(rb.Prefix+"!clients", rb.ID, time.Now().Format(time.RFC3339Nano)).Err()
+}
+
+func (rb *RedisBroker) findDeadClients() ([]string, error) {
+	clients, err := rb.client.HGetAll(rb.Prefix + "!clients").Result()
+	if err != nil {
+		return nil, err
+	}
+
+	var dead []string
+
+	for k, v := range clients {
+		if t, err := time.Parse(time.RFC3339Nano, v); err == nil {
+			if time.Since(t) >= deadDuration {
+				dead = append(dead, k)
+			}
+		} else {
+			dead = append(dead, k)
+		}
+	}
+
+	return dead, nil
+}
+
+func (rb *RedisBroker) autoReclaimDeadClients() {
+	defer rb.wg.Done()
+
+	ticker := time.NewTicker(deadCheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-rb.ctx.Done():
+			return
+		case <-ticker.C:
+			set, err := rb.client.SetNX(rb.Prefix+"!lock", rb.ID, time.Minute).Result()
+			if err != nil {
+				log.Printf("[ERR] Unable to get cleanup lock: %s", err)
+			} else if set {
+				_, err := rb.ReclaimFromDead()
+				if err != nil {
+					log.Printf("[ERR] Error reclaiming jobs from dead clients: %s", err)
+				}
+
+				err = rb.client.Del(rb.Prefix + "!lock").Err()
+				if err != nil {
+					log.Printf("[ERR] Error deleting cleanup lock: %s", err)
+				}
+			}
+		}
+	}
+}

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -1,0 +1,244 @@
+package redis
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/armon/relay"
+	"github.com/armon/relay/broker"
+	"github.com/go-redis/redis"
+	"github.com/hashicorp/go-uuid"
+)
+
+// RedisBroker implements the Broker interface in-memory
+type RedisBroker struct {
+	Prefix string
+	ID     string
+
+	closed bool
+
+	counter *uint64
+	client  *redis.Client
+
+	wg     sync.WaitGroup
+	ctx    context.Context
+	cancel func()
+}
+
+// RedisConsumer implements the Consumer interface
+type RedisConsumer struct {
+	broker  *RedisBroker
+	queue   string
+	closed  bool
+	needAck bool
+
+	lock      sync.RWMutex
+	tempQueue string
+}
+
+// RedisConsumer implements the Publisher interface
+type RedisPublisher struct {
+	broker *RedisBroker
+	queue  string
+	closed bool
+}
+
+type Options struct {
+	Addr     string
+	Password string
+	DB       int
+	Prefix   string
+}
+
+func NewRedisBroker(opts Options) *RedisBroker {
+	var ropts redis.Options
+
+	ropts.Addr = opts.Addr
+	ropts.Password = opts.Password
+	ropts.DB = opts.DB
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		panic(err)
+	}
+
+	rb := &RedisBroker{
+		Prefix: opts.Prefix,
+		ID:     id,
+
+		counter: new(uint64),
+		client:  redis.NewClient(&ropts),
+		ctx:     ctx,
+		cancel:  cancel,
+	}
+
+	rb.wg.Add(2)
+	go rb.heartbeat()
+	go rb.autoReclaimDeadClients()
+
+	return rb
+}
+
+func (i *RedisBroker) Close() error {
+	if i.closed {
+		return nil
+	}
+
+	i.closed = true
+
+	i.cancel()
+
+	i.wg.Wait()
+
+	return i.client.Close()
+}
+
+func (i *RedisBroker) listName(q string) string {
+	return fmt.Sprintf("%s:%s", i.Prefix, q)
+}
+
+func (i *RedisBroker) tempClientPrefix(id string) string {
+	// This formatting is used to avoid collisions with queue names
+	return fmt.Sprintf("%s!tmp:%s", i.Prefix, id)
+}
+
+func (i *RedisBroker) tempListName(q string) string {
+	return fmt.Sprintf("%s:%s", i.tempClientPrefix(i.ID), q)
+}
+
+func (i *RedisBroker) Consumer(q string) (broker.Consumer, error) {
+	c := &RedisConsumer{
+		broker:    i,
+		queue:     i.listName(q),
+		tempQueue: fmt.Sprintf("%s:%d", i.tempListName(q), atomic.AddUint64(i.counter, 1)),
+	}
+	return c, nil
+}
+
+func (i *RedisBroker) Publisher(q string) (broker.Publisher, error) {
+	p := &RedisPublisher{
+		broker: i,
+		queue:  i.listName(q),
+	}
+	return p, nil
+}
+
+func (i *RedisPublisher) Close() error {
+	i.closed = true
+	return nil
+}
+
+func (i *RedisPublisher) Publish(in interface{}) error {
+	data, err := json.Marshal(in)
+	if err != nil {
+		return err
+	}
+
+	return i.broker.client.LPush(i.queue, string(data)).Err()
+}
+
+func (i *RedisConsumer) Close() error {
+	if i.needAck {
+		i.Nack()
+	}
+	i.closed = true
+	return nil
+}
+
+func (i *RedisConsumer) Consume(out interface{}) error {
+	return i.ConsumeTimeout(out, 0)
+}
+
+func (i *RedisConsumer) ConsumeAck(out interface{}) error {
+	err := i.ConsumeTimeout(out, 0)
+	if err == nil {
+		return i.Ack()
+	}
+	return err
+}
+
+var ErrNeedAck = errors.New("need to ack")
+
+type timeoutI interface {
+	Timeout() bool
+}
+
+func (i *RedisConsumer) ConsumeTimeout(out interface{}, timeout time.Duration) error {
+	if i.needAck {
+		return ErrNeedAck
+	}
+
+	data, err := i.broker.client.BRPopLPush(i.queue, i.tempQueue, timeout).Bytes()
+	if err != nil {
+		if to, ok := err.(timeoutI); ok {
+			if to.Timeout() {
+				return relay.TimedOut
+			}
+		}
+
+		if err == redis.Nil {
+			return relay.TimedOut
+		}
+
+		return err
+	}
+
+	err = json.Unmarshal(data, out)
+	if err != nil {
+		return err
+	}
+
+	i.lock.Lock()
+	defer i.lock.Unlock()
+
+	// Set that we need ack
+	i.needAck = true
+
+	return nil
+}
+
+func (i *RedisConsumer) Ack() error {
+	if !i.needAck {
+		return nil
+	}
+
+	i.lock.Lock()
+	defer i.lock.Unlock()
+
+	err := i.broker.client.LPop(i.tempQueue).Err()
+	if err != nil {
+		return err
+	}
+
+	i.needAck = false
+	return nil
+}
+
+func (i *RedisConsumer) Nack() error {
+	if !i.needAck {
+		return nil
+	}
+
+	i.lock.Lock()
+	defer i.lock.Unlock()
+
+	data, err := i.broker.client.LPop(i.tempQueue).Bytes()
+	if err != nil {
+		return err
+	}
+
+	err = i.broker.client.RPush(i.queue, data).Err()
+	if err != nil {
+		return err
+	}
+
+	i.needAck = false
+	return nil
+}

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -28,6 +28,13 @@ type RedisBroker struct {
 	wg     sync.WaitGroup
 	ctx    context.Context
 	cancel func()
+
+	// The difference between the local clock and what
+	// time redis thinks it is. This is used to avoid
+	// have to sync clocks between clients and avoid
+	// asking redis for the current time constantly.
+	setTimeOffset bool
+	timeOffset    time.Duration
 }
 
 // RedisConsumer implements the Consumer interface

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -1,0 +1,362 @@
+package redis
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/armon/relay"
+	"github.com/go-redis/redis"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func CheckInteg(t *testing.T) {
+	if os.Getenv("INTEG_TESTS") != "true" {
+		t.SkipNow()
+	}
+}
+
+var prefix = "relayTest"
+
+func wipeRedis() {
+	c := redis.NewClient(&redis.Options{Addr: "127.0.0.1:6379"})
+
+	keys, err := c.Keys(prefix + "*").Result()
+	if err != nil {
+		panic(err)
+	}
+
+	if len(keys) == 0 {
+		return
+	}
+
+	err = c.Del(keys...).Err()
+	if err != nil {
+		panic(err)
+	}
+}
+
+func TestRedisBroker(t *testing.T) {
+	CheckInteg(t)
+
+	wipeRedis()
+	defer wipeRedis()
+
+	broker := NewRedisBroker(Options{
+		Addr:   "127.0.0.1:6379",
+		Prefix: prefix,
+	})
+
+	defer broker.Close()
+
+	t.Run("can publish and consume", func(t *testing.T) {
+		pub, err := broker.Publisher("test")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		err = pub.Publish("hi")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		err = pub.Publish("there")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		err = pub.Close()
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		cons, err := broker.Consumer("test")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		var out string
+		err = cons.Consume(&out)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if out != "hi" {
+			t.Fatalf("bad: %v", out)
+		}
+		err = cons.Ack()
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		err = cons.ConsumeAck(&out)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if out != "there" {
+			t.Fatalf("bad: %v", out)
+		}
+
+		cons.Close()
+	})
+
+	t.Run("can consume with timeouts", func(t *testing.T) {
+		pub, err := broker.Publisher("test")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		err = pub.Publish("joe")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		cons, err := broker.Consumer("test")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		var out string
+
+		err = cons.ConsumeTimeout(&out, 5*time.Millisecond)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if out != "joe" {
+			t.Fatalf("bad: %v", out)
+		}
+
+		// Push back
+		err = cons.Nack()
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		// Should get it back
+		err = cons.ConsumeAck(&out)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if out != "joe" {
+			t.Fatalf("bad: %v", out)
+		}
+
+		// Should timeout
+		err = cons.ConsumeTimeout(&out, 5*time.Millisecond)
+		if err != relay.TimedOut {
+			t.Fatalf("err: %v", err)
+		}
+	})
+
+	t.Run("can reclaim data from missing consumers", func(t *testing.T) {
+		pub, err := broker.Publisher("test")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		err = pub.Publish("joe2")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		cons, err := broker.Consumer("test")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		var out string
+
+		err = cons.ConsumeTimeout(&out, 5*time.Millisecond)
+		require.NoError(t, err)
+
+		require.Equal(t, "joe2", out)
+
+		// pretend that things went south
+
+		cnt, err := broker.Reclaim("test")
+		require.NoError(t, err)
+
+		assert.Equal(t, int(1), cnt)
+
+		cons, err = broker.Consumer("test")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		out = ""
+
+		err = cons.ConsumeAck(&out)
+		require.NoError(t, err)
+
+		require.Equal(t, "joe2", out)
+	})
+}
+
+func TestRedisCleanup(t *testing.T) {
+	CheckInteg(t)
+
+	wipeRedis()
+	defer wipeRedis()
+
+	before := deadDuration
+	beforeCheck := deadCheckInterval
+
+	defer func() {
+		deadDuration = before
+		deadCheckInterval = beforeCheck
+	}()
+
+	t.Run("can detect dead clients", func(t *testing.T) {
+		broker := NewRedisBroker(Options{
+			Addr:   "127.0.0.1:6379",
+			Prefix: prefix,
+		})
+
+		defer broker.Close()
+
+		broker.cancel()
+
+		deadDuration = time.Second
+
+		broker.updateHeartbeat()
+
+		list, err := broker.findDeadClients()
+		require.NoError(t, err)
+
+		require.Equal(t, 0, len(list))
+
+		time.Sleep(1 * time.Second)
+
+		list, err = broker.findDeadClients()
+		require.NoError(t, err)
+
+		require.Equal(t, 1, len(list))
+		assert.Equal(t, broker.ID, list[0])
+	})
+
+	t.Run("can reclaim data from missing consumers", func(t *testing.T) {
+		wipeRedis()
+
+		broker := NewRedisBroker(Options{
+			Addr:   "127.0.0.1:6379",
+			Prefix: prefix,
+		})
+
+		defer broker.Close()
+
+		deadDuration = time.Second
+
+		pub, err := broker.Publisher("test")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		err = pub.Publish("joe2")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		broker.updateHeartbeat()
+
+		cons, err := broker.Consumer("test")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		var out string
+
+		err = cons.ConsumeTimeout(&out, 5*time.Millisecond)
+		require.NoError(t, err)
+
+		require.Equal(t, "joe2", out)
+
+		// pretend that things went south
+
+		time.Sleep(time.Second)
+
+		cnt, err := broker.ReclaimFromDead()
+		require.NoError(t, err)
+
+		assert.Equal(t, int(1), cnt)
+
+		cons, err = broker.Consumer("test")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		out = ""
+
+		err = cons.ConsumeTimeout(&out, time.Second)
+		require.NoError(t, err)
+
+		cons.Ack()
+
+		require.Equal(t, "joe2", out)
+	})
+
+	t.Run("automatically cleans up dead clients", func(t *testing.T) {
+		wipeRedis()
+
+		broker := NewRedisBroker(Options{
+			Addr:   "127.0.0.1:6379",
+			Prefix: prefix,
+		})
+
+		defer broker.Close()
+
+		deadDuration = time.Second
+		deadCheckInterval = 2 * time.Second
+
+		pub, err := broker.Publisher("test")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		err = pub.Publish("joe2")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		cons, err := broker.Consumer("test")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		var out string
+
+		err = cons.ConsumeTimeout(&out, 5*time.Millisecond)
+		require.NoError(t, err)
+
+		require.Equal(t, "joe2", out)
+
+		// pretend that things went south
+
+		broker.cancel()
+
+		time.Sleep(deadCheckInterval)
+
+		b2 := NewRedisBroker(Options{
+			Addr:   "127.0.0.1:6379",
+			Prefix: prefix,
+		})
+
+		defer b2.Close()
+
+		time.Sleep(time.Second)
+
+		cons, err = broker.Consumer("test")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		out = ""
+
+		err = cons.ConsumeTimeout(&out, time.Second)
+		require.NoError(t, err)
+
+		cons.Ack()
+
+		require.Equal(t, "joe2", out)
+	})
+
+}

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -50,6 +50,14 @@ func TestRedisBroker(t *testing.T) {
 
 	defer broker.Close()
 
+	t.Run("can calculate the time relative to redis", func(t *testing.T) {
+		cur := time.Unix(0, broker.currentTime())
+
+		assert.InDelta(t, time.Now().Sub(cur).Seconds(), 0.0, 0.1)
+		assert.True(t, broker.setTimeOffset)
+		assert.InDelta(t, broker.timeOffset.Seconds(), 0.0, 0.1)
+	})
+
 	t.Run("can publish and consume", func(t *testing.T) {
 		pub, err := broker.Publisher("test")
 		if err != nil {


### PR DESCRIPTION
This adds broker implementation that uses redis to send data between
publishers and consumers. It uses the reliable message pattern for redis
using BRPOPLPUSH to be careful to not orphan data within a worker before
it is acknowledged.

All brokers checker on all other brokers for ones that have become dead
for any reason. If a dead broken is detected, it's unacked messages are
reclaimed back into the original queue to be handled. This behavior is
automatic and does not require an additional cleanup broker.