### PR TITLE
 Fix relay lib

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -8,6 +8,7 @@ type Broker interface {
 	Close() error
 	Consumer(queue string) (Consumer, error)
 	Publisher(queue string) (Publisher, error)
+	PublisherWithRoutingKey(queue string, routingKey string) (Publisher, error)
 }
 
 // Publisher is used to push messages into a queue

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/WinnerSoftLab/relay
+
+go 1.13
+
+require (
+	github.com/hashicorp/go-uuid v1.0.2
+	github.com/streadway/amqp v1.0.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2IGE=
+github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/streadway/amqp v1.0.0 h1:kuuDrUJFZL1QYL9hUNuCxNObNzB0bV/ZG5jV3RWAQgo=
+github.com/streadway/amqp v1.0.0/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=

--- a/inmem/inmem.go
+++ b/inmem/inmem.go
@@ -5,8 +5,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/armon/relay"
-	"github.com/armon/relay/broker"
+	"github.com/WinnerSoftLab/relay"
+	"github.com/WinnerSoftLab/relay/broker"
 )
 
 // InmemBroker implements the Broker interface in-memory

--- a/inmem/inmem_test.go
+++ b/inmem/inmem_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/armon/relay"
+	"github.com/WinnerSoftLab/relay"
 )
 
 func TestInmemBroker(t *testing.T) {

--- a/pq/pq.go
+++ b/pq/pq.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/armon/relay/broker"
+	"github.com/WinnerSoftLab/relay/broker"
 )
 
 // The pq package provides a simple priority queue. All that is required is a

--- a/pq/pq_test.go
+++ b/pq/pq_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/armon/relay/inmem"
+	"github.com/WinnerSoftLab/relay/inmem"
 )
 
 func TestPriorityQueue(t *testing.T) {

--- a/relay.go
+++ b/relay.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/armon/relay/broker"
+	"github.com/WinnerSoftLab/relay/broker"
 	"github.com/streadway/amqp"
 )
 
@@ -28,6 +28,7 @@ type Config struct {
 	Serializer            Serializer    // Defaults to GOBSerializer
 	MessageTTL            time.Duration // Optional, attempts to put a TTL on message life
 	QueueTTL              time.Duration // Optional, attempts to make a TTL on a queue life
+	WithoutPrefix         bool          // by default "relay." prefix will be used for legacy support
 }
 
 type Relay struct {
@@ -280,7 +281,7 @@ func (r *Relay) ConsumerWithRoutingKey(queue string, routingKey string) (*Consum
 	}()
 
 	// Ensure the queue exists
-	name := queueName(queue)
+	name := queueName(queue, r.conf.WithoutPrefix)
 	if err := r.declareQueue(ch, name, routingKey); err != nil {
 		return nil, err
 	}
@@ -334,7 +335,7 @@ func (r *Relay) PublisherWithRoutingKey(queue string, routingKey string) (*Publi
 	}()
 
 	// Ensure the queue exists
-	name := queueName(queue)
+	name := queueName(queue, r.conf.WithoutPrefix)
 	if err := r.declareQueue(ch, name, routingKey); err != nil {
 		return nil, err
 	}

--- a/relay.go
+++ b/relay.go
@@ -6,8 +6,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/WinnerSoftLab/relay/broker"
 	"github.com/streadway/amqp"
+
+	"github.com/WinnerSoftLab/relay/broker"
 )
 
 // Config is passed into New when creating a Relay to tune
@@ -334,10 +335,12 @@ func (r *Relay) PublisherWithRoutingKey(queue string, routingKey string) (*Publi
 		}
 	}()
 
-	// Ensure the queue exists
 	name := queueName(queue, r.conf.WithoutPrefix)
-	if err := r.declareQueue(ch, name, routingKey); err != nil {
-		return nil, err
+	if queue != "" { // do not create exclusive queue for publisher w/o consumers
+		// Ensure the queue exists
+		if err := r.declareQueue(ch, name, routingKey); err != nil {
+			return nil, err
+		}
 	}
 
 	// Determine content type
@@ -388,6 +391,10 @@ func (r *relayBroker) Close() error {
 
 func (r *relayBroker) Publisher(q string) (broker.Publisher, error) {
 	return r.relay.Publisher(q)
+}
+
+func (r *relayBroker) PublisherWithRoutingKey(queue string, routingKey string) (broker.Publisher, error) {
+	return r.relay.PublisherWithRoutingKey(queue, routingKey)
 }
 
 func (r *relayBroker) Consumer(q string) (broker.Consumer, error) {

--- a/retry.go
+++ b/retry.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/armon/relay/broker"
+	"github.com/WinnerSoftLab/relay/broker"
 )
 
 var (

--- a/retry_test.go
+++ b/retry_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/armon/relay/broker"
+	"github.com/WinnerSoftLab/relay/broker"
 	"github.com/hashicorp/go-uuid"
 )
 

--- a/util.go
+++ b/util.go
@@ -9,9 +9,9 @@ import (
 )
 
 // Converts the user input name into the actual name
-func queueName(name string) string {
+func queueName(name string, withoutPrefix bool) string {
 	// Allow using a nameless queue
-	if name == "" {
+	if name == "" || withoutPrefix {
 		return name
 	}
 

--- a/util_test.go
+++ b/util_test.go
@@ -5,10 +5,13 @@ import (
 )
 
 func TestQueueName(t *testing.T) {
-	if name := queueName("test"); name != "relay.test" {
+	if name := queueName("test", false); name != "relay.test" {
 		t.Fatalf("bad queue name: %q", name)
 	}
-	if name := queueName(""); name != "" {
+	if name := queueName("", false); name != "" {
+		t.Fatalf("bad queue name: %q", name)
+	}
+	if name := queueName("test", true); name != "test" {
 		t.Fatalf("bad queue name: %q", name)
 	}
 }


### PR DESCRIPTION
1. Do not create exclusive queue for publisher (useless queue w/o any consumers)
2. Allow to create publisher without queue but with routing key
3. Add go.mod for future delivery switching from dep to mod